### PR TITLE
Improve frontend styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,8 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Aggregator</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body class="min-h-screen bg-gradient-to-br from-indigo-100 via-purple-100 to-pink-100 text-gray-800 font-sans">
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>
 </body>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,7 @@ export default function App() {
   return (
     <>
       <Navbar />
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 py-8 mt-8 bg-white/80 backdrop-blur-lg rounded-xl shadow-xl">
         <Routes>
           <Route path="/" element={<Home />} />
           <Route

--- a/frontend/src/components/FileDropZone.jsx
+++ b/frontend/src/components/FileDropZone.jsx
@@ -4,10 +4,10 @@ export default function FileDropZone({ onFileSelect }) {
   const ref = useRef();
   return (
     <div
-      className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center cursor-pointer hover:bg-gray-50"
+      className="border-2 border-dashed border-indigo-300 rounded-lg p-6 text-center cursor-pointer bg-white/60 hover:bg-white"
       onClick={() => ref.current.click()}
     >
-      <p className="text-gray-600">Click or drag PDF here</p>
+      <p className="text-gray-700">Click or drag PDF here</p>
       <input
         type="file"
         accept=".pdf"

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -3,9 +3,12 @@ import { NavLink } from "react-router-dom";
 export default function Navbar() {
   const linkCls = "hover:text-blue-600 px-2 py-1 rounded";
   return (
-    <nav className="bg-white shadow">
+    <nav className="bg-white/80 backdrop-blur shadow">
       <div className="container mx-auto px-4 py-4 flex justify-between">
-        <NavLink to="/" className="font-bold text-xl">
+        <NavLink
+          to="/"
+          className="font-extrabold text-xl bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent"
+        >
           Aggregator
         </NavLink>
         <div className="space-x-4">

--- a/frontend/src/components/ObligationList.jsx
+++ b/frontend/src/components/ObligationList.jsx
@@ -2,8 +2,12 @@ export default function ObligationList({ obligations }) {
   if (!obligations.length)
     return <p className="italic text-gray-500">No obligations found.</p>;
   return (
-    <ul className="list-disc list-inside space-y-2">
-      {obligations.map((o,i) => <li key={i}>{o}</li>)}
+    <ul className="space-y-3">
+      {obligations.map((o, i) => (
+        <li key={i} className="bg-white/70 rounded-lg p-4 shadow">
+          {o}
+        </li>
+      ))}
     </ul>
   );
 }

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -1,7 +1,7 @@
 export default function About() {
   return (
     <>
-      <h2 className="text-2xl font-semibold mb-4">About Aggregator</h2>
+      <h2 className="text-3xl font-extrabold mb-6 bg-gradient-to-r from-blue-600 to-purple-600 text-transparent bg-clip-text">About Aggregator</h2>
       <p className="mb-4">
         Aggregator analyses legislation PDFs with OpenAI’s GPT-4o to surface
         company-specific compliance obligations.

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,14 +1,16 @@
 import { Link } from "react-router-dom";
 export default function Home() {
   return (
-    <div className="text-center space-y-4">
-      <h1 className="text-4xl font-bold">Welcome to Aggregator</h1>
-      <p className="text-lg text-gray-600">
+    <div className="text-center space-y-6 py-12">
+      <h1 className="text-5xl font-extrabold bg-gradient-to-r from-blue-600 to-purple-600 text-transparent bg-clip-text">
+        Welcome to Aggregator
+      </h1>
+      <p className="text-lg text-gray-700">
         Upload legislation PDFs and get compliance obligations.
       </p>
       <Link
         to="/upload"
-        className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700"
+        className="bg-gradient-to-r from-blue-600 to-purple-600 text-white px-8 py-3 rounded-lg shadow-lg hover:opacity-90"
       >
         Get Started
       </Link>

--- a/frontend/src/pages/Results.jsx
+++ b/frontend/src/pages/Results.jsx
@@ -10,11 +10,14 @@ export default function Results({ company, obligations }) {
     );
   return (
     <>
-      <h2 className="text-2xl font-semibold mb-4">
-        Obligations for <span className="text-blue-700">{company}</span>
+      <h2 className="text-3xl font-extrabold mb-6 bg-gradient-to-r from-blue-600 to-purple-600 text-transparent bg-clip-text">
+        Obligations for <span>{company}</span>
       </h2>
       <ObligationList obligations={obligations} />
-      <Link to="/upload" className="mt-6 inline-block text-blue-600 hover:underline">
+      <Link
+        to="/upload"
+        className="mt-6 inline-block text-blue-600 hover:text-purple-600 font-medium"
+      >
         ← Back to upload
       </Link>
     </>

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -27,7 +27,7 @@ export default function Upload({ setObligations, setCompany }) {
 
   return (
     <>
-      <h2 className="text-2xl font-semibold mb-4">Upload Legislation</h2>
+      <h2 className="text-3xl font-extrabold mb-6 bg-gradient-to-r from-blue-600 to-purple-600 text-transparent bg-clip-text">Upload Legislation</h2>
       <form onSubmit={submit} className="space-y-4">
         <div>
           <label className="block mb-1 font-medium">Company Name</label>
@@ -42,7 +42,7 @@ export default function Upload({ setObligations, setCompany }) {
         {file && <p className="text-sm text-gray-500">Selected: {file.name}</p>}
         <button
           disabled={loading}
-          className="bg-green-600 text-white px-5 py-2 rounded hover:bg-green-700 disabled:opacity-50"
+          className="bg-gradient-to-r from-green-600 to-emerald-600 text-white px-6 py-2 rounded shadow hover:opacity-90 disabled:opacity-50"
         >
           {loading ? "Processing…" : "Extract Obligations"}
         </button>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,11 +1,17 @@
 /** @type {import('tailwindcss').Config} */
+import defaultTheme from 'tailwindcss/defaultTheme'
+
 export default {
   content: [
-    "./index.html",
-    "./src/**/*.{js,jsx}"
+    './index.html',
+    './src/**/*.{js,jsx}'
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add Google font and gradient background
- configure Tailwind with Inter font
- add blurred container in App
- style navbar and pages with gradient text and buttons
- upgrade drop zone and obligation list style

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bc1a4d424832c88bcd4ef56135823